### PR TITLE
Initial version of component-variantify

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.log
+*.js
+bundle.css
+*.html
+!karma.conf.js
+assets/

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ structure, content or behaviour are required.
 
 ```javascript
 import { createVariant } from '@economist/component-variantify';
-import ArticleBodyComponent from './body';
+import ArticleBodyTemplate from './body';
 import TabView from '@economist/component-tabview';
 
 const WorldIfArticleBody = createVariant({
   Blockquote: 'blockquote',
   TabView: TabView,
-}, 'world-if')(ArticleTemplate);
+}, 'world-if')(ArticleBodyTemplate);
 
 const data = {};
 return (

--- a/README.md
+++ b/README.md
@@ -6,39 +6,24 @@ A higher-order component that offers a common way of creating component variants
 Its purpose is to help wrap generalised components when specialised styling,
 structure, content or behaviour are required.
 
-A `variantName` can be passed in as a `prop`, like so `<VariantComponentSwitcher variantName="look-or-feel-id" />`, to:
-
-1. Prefix the class name of the component it wraps
-2. Alter the inner components of the component it wraps
-
 ## Goals
 
 - [x] Allows a developer to *variantify* as little or as much as they want. You are not forced to do masses of overriding when you only want to change one thing (e.g. the `ArticleHeader` is swapped, but the rest is vanilla).
 - [x] Allows variants with radically-different HTML to co-exist.
-- [x] Separation of styling concerns using variant-specific classes. Attempts to avoid styling clashes.  
+- [x] Separation of styling concerns using variant-specific classes. Attempts to avoid styling clashes.
 - [x] A common interface to describe variants and to enable easy switching between them using a property. Useful in future for A/B testing.
-
-## Design
-
-`createVariantSwitcher` calls `withSwitchableInnerComponents`
-
-`withSwitchableInnerComponents` allows a developer to declaratively switch between the components that are composed by the wrapped component. It calls `createVariant` behind the scenes.
-
-`createVariant` creates a component with some injected `components` and also uses `withVariantClassNameList` against the component that it composes.
-
-`withVariantClassNameList` gives a developer a helper function
-`generateClassNameList` that will generate additional variant classes when
-passed a class name.
 
 ## Usage
 
 ```javascript
 import { createVariant } from '@economist/component-variantify';
 import ArticleBodyComponent from './body';
+import TabView from '@economist/component-tabview';
 
 const WorldIfArticleBody = createVariant({
   Blockquote: 'blockquote',
-}, 'world-if');
+  TabView: TabView,
+}, 'world-if')(ArticleTemplate);
 
 const data = {};
 return (
@@ -48,6 +33,28 @@ return (
 
 [See `example.es6` for further usage instructions.](./example.es6)
 
+## Design
+
+A function `createVariant` is provided that will:
+
+1. Prefix the class name of the component it wraps
+2. Alter the inner components of the component it wraps
+
+There is also another function exposed by default: `createVariantSwitcher`.
+When using this `variantName` can be passed in as a `prop` to affect the inner components that are passed into the `Component` it wraps. Like so:
+
+`<VariantComponentSwitcher variantName="look-or-feel-id" />`.
+
+#### NOTES
+
+`createVariantSwitcher` wraps a component with `withSwitchableInnerComponents`
+
+`withSwitchableInnerComponents` allows a developer to declaratively switch between the components that should be rendered by the wrapped component. It calls `createVariant` behind the scenes.
+
+`createVariant` creates a component with some injected `components` and also wraps this component with `withVariantClassNameList`.
+
+`withVariantClassNameList` gives a developer a helper function
+`generateClassNameList` that will generate additional variant classes when passed a class name.
 
 ## Install
 
@@ -63,11 +70,11 @@ npm test;
 
 ## Creating a new variant
 
-Create an `index.es6` like so:
+First, you must have a `*Template` component that renders itself based on a `props.components` object.
+
+Then you must create an `index.es6` like so:
 ```javascript
 import createVariantSwitcher from '@economist/component-variantify';
-// The ArticleTemplate must have a `components`
-// prop that is used to render its elements.
 import ArticleTemplate from '@economist/component-articletemplate';
 
 import {
@@ -104,7 +111,7 @@ const config = {
 export default createVariantSwitcher(config)(ArticleTemplate);
 ```
 
-Create an `index.css` like so, and import it in your `App`'s styling:
+And finally, create an `index.css` and import it in your `App`'s styling:
 ```css
 .variant-name-article-template__container {
   // ...

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A higher-order component that offers a common way of creating component variants
 Its purpose is to help wrap generalised components when specialised styling,
 structure, content or behaviour are required.
 
-A `variantName` can be passed in as a `prop` to:
+A `variantName` can be passed in as a `prop`, like so `<VariedComponent variantName="look-or-feel-id" />`, to:
 
 1. Prefix the class name of the component it wraps
 2. Alter the inner components of the component it wraps

--- a/README.md
+++ b/README.md
@@ -67,28 +67,23 @@ import {
 
 const defaults = {
   defaultVariant: 'variant-name',
-  variants: [
-    'variant-name',
-    'other-variant-name',
-  ],
-};
-
-const variantInnerComponents = {
-  'variant-name': {
-    ArticleHeader: VariantHeader,
-    ArticleSubheader: VariantSubheader,
-    ArticleBody: VariantBody,
-    ArticleFooter: VariantFooter,
-  },
-  'other-variant-name': {
-    ArticleHeader: OtherVariantHeader,
-    ArticleSubheader: OtherVariantSubheader,
-    ArticleBody: OtherVariantBody,
-    ArticleFooter: OtherVariantFooter,
+  variants: {
+    'variant-name': {
+      ArticleHeader: VariantHeader,
+      ArticleSubheader: VariantSubheader,
+      ArticleBody: VariantBody,
+      ArticleFooter: VariantFooter,
+    },
+    'other-variant-name': {
+      ArticleHeader: OtherVariantHeader,
+      ArticleSubheader: OtherVariantSubheader,
+      ArticleBody: OtherVariantBody,
+      ArticleFooter: OtherVariantFooter,
+    },
   },
 };
 
-export default variantify(defaults, variantInnerComponents)(ArticleTemplate);
+export default variantify(defaults)(ArticleTemplate);
 ```
 
 Create an `index.css` like so, and import it in your `App`'s styling:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A higher-order component that offers a common way of creating component variants
 Its purpose is to help wrap generalised components when specialised styling,
 structure, content or behaviour are required.
 
-A `variantName` can be passed in as a `prop`, like so `<VariedComponent variantName="look-or-feel-id" />`, to:
+A `variantName` can be passed in as a `prop`, like so `<VariantComponentSwitcher variantName="look-or-feel-id" />`, to:
 
 1. Prefix the class name of the component it wraps
 2. Alter the inner components of the component it wraps
@@ -20,10 +20,11 @@ A `variantName` can be passed in as a `prop`, like so `<VariedComponent variantN
 
 ## Design
 
-`variantify` is a composition of `withVariedInnerComponents` and `withVariantClassNameList`.
+`createVariantSwitcher` calls `withSwitchableInnerComponents`
 
-`withVariedInnerComponents` allows a developer to declaratively specify the
-components that are composed by the wrapped component.
+`withSwitchableInnerComponents` allows a developer to declaratively switch between the components that are composed by the wrapped component. It calls `createVariant` behind the scenes.
+
+`createVariant` creates a component with some injected `components` and also uses `withVariantClassNameList` against the component that it composes.
 
 `withVariantClassNameList` gives a developer a helper function
 `generateClassNameList` that will generate additional variant classes when
@@ -31,7 +32,22 @@ passed a class name.
 
 ## Usage
 
-[See `example.es6` for usage instructions.](./example.es6)
+```javascript
+import { createVariant } from '@economist/component-variantify';
+import ArticleBodyComponent from './body';
+
+const WorldIfArticleBody = createVariant({
+  Blockquote: 'blockquote',
+}, 'world-if');
+
+const data = {};
+return (
+  <WorldIfArticleBody {...data} />
+)
+```
+
+[See `example.es6` for further usage instructions.](./example.es6)
+
 
 ## Install
 
@@ -49,7 +65,9 @@ npm test;
 
 Create an `index.es6` like so:
 ```javascript
-import variantify from '@economist/component-variantify';
+import createVariantSwitcher from '@economist/component-variantify';
+// The ArticleTemplate must have a `components`
+// prop that is used to render its elements.
 import ArticleTemplate from '@economist/component-articletemplate';
 
 import {
@@ -83,7 +101,7 @@ const config = {
   },
 };
 
-export default variantify(config)(ArticleTemplate);
+export default createVariantSwitcher(config)(ArticleTemplate);
 ```
 
 Create an `index.css` like so, and import it in your `App`'s styling:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A `variantName` can be passed in as a `prop` to:
 
 ## Goals
 
-- [x] Allows a developer to *variantify* as little or as much as they want. You are not forced to do masses of overriding when you only want to change one thing.
+- [x] Allows a developer to *variantify* as little or as much as they want. You are not forced to do masses of overriding when you only want to change one thing (e.g. the `ArticleHeader` is swapped, but the rest is vanilla).
 - [x] Allows variants with radically-different HTML to co-exist.
 - [x] Separation of styling concerns using variant-specific classes. Attempts to avoid styling clashes.  
 - [x] A common interface to describe variants and to enable easy switching between them using a property. Useful in future for A/B testing.
@@ -93,7 +93,7 @@ export default variantify(defaults, variantInnerComponents)(ArticleTemplate);
 
 Create an `index.css` like so, and import it in your `App`'s styling:
 ```css
-.variant-name-ArticleTemplate--container {
+.variant-name-article-template__container {
   // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ A function `createVariant` is provided that will:
 1. Prefix the class name of the component it wraps
 2. Alter the inner components of the component it wraps
 
-There is also another function exposed by default: `createVariantSwitcher`.
-When using this `variantName` can be passed in as a `prop` to affect the inner components that are passed into the `Component` it wraps. Like so:
+By default, the function `createVariantSwitcher` is exposed. When using this `variantName` can be passed in within `props` to affect the inner components that are passed into the `Component` it wraps. Like so:
 
 `<VariantComponentSwitcher variantName="look-or-feel-id" />`.
 
-#### NOTES
+__________
+
+###### NOTES
 
 `createVariantSwitcher` wraps a component with `withSwitchableInnerComponents`
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import {
   OtherVariantFooter,
 } from './other-variant-items';
 
-const defaults = {
+const config = {
   defaultVariant: 'variant-name',
   variants: {
     'variant-name': {
@@ -83,7 +83,7 @@ const defaults = {
   },
 };
 
-export default variantify(defaults)(ArticleTemplate);
+export default variantify(config)(ArticleTemplate);
 ```
 
 Create an `index.css` like so, and import it in your `App`'s styling:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
 # component-variantify
+> HOCs to help create variants of components
 
+A higher-order component that offers a common way of creating component variants.
+
+Its purpose is to help wrap generalised components when specialised styling,
+structure, content or behaviour are required.
+
+A `variantName` can be passed in as a `prop` to:
+
+1. Prefix the class name of the component it wraps
+2. Alter the inner components of the component it wraps
+
+## Goals
+
+- [x] Allows a developer to *variantify* as little or as much as they want. You are not forced to do masses of overriding when you only want to change one thing.
+- [x] Allows variants with radically-different HTML to co-exist.
+- [x] Separation of styling concerns using variant-specific classes. Attempts to avoid styling clashes.  
+- [x] A common interface to describe variants and to enable easy switching between them using a property. Useful in future for A/B testing.
+
+## Design
+
+`variantify` is a composition of `withVariedInnerComponents` and `withVariantClassNameList`.
+
+`withVariedInnerComponents` allows a developer to declaratively specify the
+components that are composed by the wrapped component.
+
+`withVariantClassNameList` gives a developer a helper function
+`generateClassNameList` that will generate additional variant classes when
+passed a class name.
+
+## Usage
+
+[See `example.es6` for usage instructions.](./example.es6)
+
+## Install
+
+```
+npm install --save @economist/component-variantify;
+```
+
+## Run tests
+
+```
+npm test;
+```
+
+## Creating a new variant
+
+Create an `index.es6` like so:
+```javascript
+import variantify from '@economist/component-variantify';
+import ArticleTemplate from '@economist/component-articletemplate';
+
+import {
+  VariantHeader,
+  VariantSubheader,
+  VariantBody,
+  VariantFooter,
+} from './variant-items';
+import {
+  OtherVariantHeader,
+  OtherVariantSubheader,
+  OtherVariantBody,
+  OtherVariantFooter,
+} from './other-variant-items';
+
+const defaults = {
+  defaultVariant: 'variant-name',
+  variants: [
+    'variant-name',
+    'other-variant-name',
+  ],
+};
+
+const variantInnerComponents = {
+  'variant-name': {
+    ArticleHeader: VariantHeader,
+    ArticleSubheader: VariantSubheader,
+    ArticleBody: VariantBody,
+    ArticleFooter: VariantFooter,
+  },
+  'other-variant-name': {
+    ArticleHeader: OtherVariantHeader,
+    ArticleSubheader: OtherVariantSubheader,
+    ArticleBody: OtherVariantBody,
+    ArticleFooter: OtherVariantFooter,
+  },
+};
+
+export default variantify(defaults, variantInnerComponents)(ArticleTemplate);
+```
+
+Create an `index.css` like so, and import it in your `App`'s styling:
+```css
+.variant-name-ArticleTemplate--container {
+  // ...
+}
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SSH_KEY="${1:-/root/.ssh/id_rsa}"
+DOCKER_IMAGE="economistprod/node4-base"
+HOST_IP=$(ip route get 1 | awk '{print $NF;exit}')
+SINOPIA_URL="http://${HOST_IP}:4873"
+
+[[ ${NPM_TOKEN:-} = '' ]] && { echo "NPM_TOKEN empty"; exit 1; }
+[[ ${SAUCE_ACCESS_KEY:-} = '' ]] && { echo "SAUCE_ACCESS_KEY empty"; exit 2; }
+[[ ${SAUCE_USERNAME:-} = '' ]] && { echo "SAUCE_USERNAME empty"; exit 3; }
+
+docker pull "${DOCKER_IMAGE}"
+
+exec docker run \
+    -v "${SSH_KEY}":/root/.ssh/id_rsa \
+    -v "$(pwd)":/code \
+    -e NODE_ENV=${NODE_ENV:-test} \
+    "${DOCKER_IMAGE}" \
+    /bin/sh -cx "\
+        trap 'chmod 777 node_modules -R' EXIT && \
+        cd /code && \
+        umask 000 && \
+        printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n\" > ~/.npmrc && \
+        (curl -I ${SINOPIA_URL} --max-time 5 && npm set registry ${SINOPIA_URL} && echo \"Using sinopia cache registry available on ${SINOPIA_URL}\" || true) && \
+        npm i && \
+        echo npm run doc:js && \
+        echo SAUCE_USERNAME=${SAUCE_USERNAME} SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} npm t && \
+        { git config --global user.email 'ecprod@economist.com'; git config --global user.name 'GoCD'; true; } && \
+        { [ \"$(git rev-parse --abbrev-ref HEAD)\" != \"master\" ] || npm run pages; } ; \
+        RETURN_CODE=\$?; \
+        echo \"Build finished with status \${RETURN_CODE}\"; \
+        exit \${RETURN_CODE}
+    ";
+
+

--- a/example.es6
+++ b/example.es6
@@ -36,35 +36,34 @@ class ComposedComponent extends React.Component {
 }
 
 const defaults = {
-  variants: [ 'basic', 'extended' ],
   defaultVariant: 'basic',
-};
-const variantInnerComponents = {
-  'basic': {
-    'Information': ({ title, director }) => (
-      <div>
-        <h1>{title} by {director}</h1>
-      </div>
-    ),
+  variants: {
+    'basic': {
+      'Information': ({ title, director }) => (
+        <div>
+          <h1>{title} by {director}</h1>
+        </div>
+      ),
+    },
+    'extended': {
+      'Information': ({ title, director, synopsis, rating }) => (
+        <ul>
+          <li><strong>{title}</strong> ({rating})</li>
+          <li>Director: {director}</li>
+          <li>Synopsis: {synopsis}</li>
+        </ul>
+      ),
+    },
   },
-  'extended': {
-    'Information': ({ title, director, synopsis, rating }) => (
-      <ul>
-        <li><strong>{title}</strong> ({rating})</li>
-        <li>Director: {director}</li>
-        <li>Synopsis: {synopsis}</li>
-      </ul>
-    ),
-  },
 };
-const VariantComponent = variantify(defaults, variantInnerComponents)(ComposedComponent);
+const VariantSwitcherComponent = variantify(defaults)(ComposedComponent);
 export default (
   <div>
-    <VariantComponent
+    <VariantSwitcherComponent
       title="E.T."
       director="Steven Spielberg"
     />
-    <VariantComponent
+    <VariantSwitcherComponent
       variantName="extended"
       title="Trust"
       director="Hal Hartley"

--- a/example.es6
+++ b/example.es6
@@ -35,7 +35,7 @@ class ComposedComponent extends React.Component {
 
 }
 
-const defaults = {
+const config = {
   defaultVariant: 'basic',
   variants: {
     'basic': {
@@ -56,7 +56,7 @@ const defaults = {
     },
   },
 };
-const VariantSwitcherComponent = variantify(defaults)(ComposedComponent);
+const VariantSwitcherComponent = variantify(config)(ComposedComponent);
 export default (
   <div>
     <VariantSwitcherComponent

--- a/example.es6
+++ b/example.es6
@@ -1,0 +1,75 @@
+import React, { PropTypes } from 'react';
+import variantify, { defaultGenerateClassNameList } from '.';
+
+const isComponent = PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]);
+class ComposedComponent extends React.Component {
+
+  static propTypes = {
+    generateClassNameList: PropTypes.func,
+    components: PropTypes.shape({
+      Information: isComponent,
+    }),
+  };
+
+  static defaultProps = {
+    generateClassNameList: defaultGenerateClassNameList,
+    components: {
+      Information: () => <div>Nothing by default</div>,
+    },
+  };
+
+  render() {
+    const { generateClassNameList, components = {}, ...remainingProps } = this.props;
+    const { Information } = components;
+    return (
+      <div className={generateClassNameList('composed-component').join(' ')}>
+        <span className={generateClassNameList('composed-component__header').join(' ')}>
+          Details of <strong>film</strong>
+        </span>
+        <div className={generateClassNameList('composed-component__body').join(' ')}>
+          <Information {...remainingProps} />
+        </div>
+      </div>
+    );
+  }
+
+}
+
+const defaults = {
+  variants: [ 'basic', 'extended' ],
+  defaultVariant: 'basic',
+};
+const variantInnerComponents = {
+  'basic': {
+    'Information': ({ title, director }) => (
+      <div>
+        <h1>{title} by {director}</h1>
+      </div>
+    ),
+  },
+  'extended': {
+    'Information': ({ title, director, synopsis, rating }) => (
+      <ul>
+        <li><strong>{title}</strong> ({rating})</li>
+        <li>Director: {director}</li>
+        <li>Synopsis: {synopsis}</li>
+      </ul>
+    ),
+  },
+};
+const VariantComponent = variantify(defaults, variantInnerComponents)(ComposedComponent);
+export default (
+  <div>
+    <VariantComponent
+      title="E.T."
+      director="Steven Spielberg"
+    />
+    <VariantComponent
+      variantName="extended"
+      title="Trust"
+      director="Hal Hartley"
+      synopsis="...blah blah blah..."
+      rating="5 stars"
+    />
+  </div>
+);

--- a/example.es6
+++ b/example.es6
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import variantify, { defaultGenerateClassNameList } from '.';
+import createVariantSwitcher, { defaultGenerateClassNameList } from '.';
 
 const isComponent = PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]);
 class ComposedComponent extends React.Component {
@@ -56,7 +56,7 @@ const config = {
     },
   },
 };
-const VariantSwitcherComponent = variantify(config)(ComposedComponent);
+const VariantSwitcherComponent = createVariantSwitcher(config)(ComposedComponent);
 export default (
   <div>
     <VariantSwitcherComponent

--- a/index.es6
+++ b/index.es6
@@ -3,7 +3,7 @@ import compose from 'lodash.compose';
 
 export const defaultGenerateClassNameList = (defaultClassName) => [ defaultClassName ];
 
-export function withVariedInnerComponents(variantNameComponents = {}, defaultVariant) {
+export function withVariedInnerComponents({ variants = {}, defaultVariant }) {
   return (ComposedComponent) => class WithVariedInnerComponents extends Component {
     render() {
       const { variantName, ...remainingProps } = this.props;
@@ -11,7 +11,7 @@ export function withVariedInnerComponents(variantNameComponents = {}, defaultVar
       // otherwise just pass the remainingProps and variantName.
       const components = Object.assign(
         (ComposedComponent.defaultProps || {}).components || {},
-        variantNameComponents[variantName] || variantNameComponents[defaultVariant] || {}
+        variants[variantName] || variants[defaultVariant] || {}
       );
       return (
         <ComposedComponent
@@ -24,12 +24,12 @@ export function withVariedInnerComponents(variantNameComponents = {}, defaultVar
   };
 }
 
-export function withVariantClassNameList({ variants = [], defaultVariant }) {
+export function withVariantClassNameList({ variants = {}, defaultVariant }) {
   return (ComposedComponent) => class WithVariantClassNameListComponent extends Component {
 
     static get propTypes() {
       return {
-        variantName: PropTypes.oneOf(variants),
+        variantName: PropTypes.oneOf(Object.keys(variants)),
       };
     }
 
@@ -63,9 +63,9 @@ export function withVariantClassNameList({ variants = [], defaultVariant }) {
   };
 }
 
-export default function variantify(defaults = {}, variantNameComponents = {}) {
+export default function variantify(defaults = {}) {
   return compose(
-    withVariedInnerComponents(variantNameComponents, defaults.defaultVariant),
+    withVariedInnerComponents(defaults),
     withVariantClassNameList(defaults)
   );
 }

--- a/index.es6
+++ b/index.es6
@@ -1,0 +1,71 @@
+import React, { Component, PropTypes } from 'react';
+import compose from 'lodash.compose';
+
+export const defaultGenerateClassNameList = (defaultClassName) => [ defaultClassName ];
+
+export function withVariedInnerComponents(variantNameComponents = {}, defaultVariant) {
+  return (ComposedComponent) => class WithVariedInnerComponents extends Component {
+    render() {
+      const { variantName, ...remainingProps } = this.props;
+      // If variant-specific omponents were found then passthrough,
+      // otherwise just pass the remainingProps and variantName.
+      const components = Object.assign(
+        (ComposedComponent.defaultProps || {}).components || {},
+        variantNameComponents[variantName] || variantNameComponents[defaultVariant] || {}
+      );
+      return (
+        <ComposedComponent
+          variantName={variantName}
+          components={components}
+          {...remainingProps}
+        />
+      );
+    }
+  };
+}
+
+export function withVariantClassNameList({ variants = [], defaultVariant }) {
+  return (ComposedComponent) => class WithVariantClassNameListComponent extends Component {
+
+    static get propTypes() {
+      return {
+        variantName: PropTypes.oneOf(variants),
+      };
+    }
+
+    static get defaultProps() {
+      return {
+        variantName: defaultVariant,
+      };
+    }
+
+    getVariantClassNameListGetter(variantName) {
+      return (specifiedClassName) => {
+        const classNameList = [ specifiedClassName ];
+        if (variantName) {
+          classNameList.unshift(`${variantName}-${specifiedClassName}`);
+        }
+        return classNameList;
+      };
+    }
+
+    render() {
+      const { variantName, ...remainingProps } = this.props;
+      const generateClassNameList = this.getVariantClassNameListGetter(variantName);
+      return (
+        <ComposedComponent
+          variantName={variantName}
+          generateClassNameList={generateClassNameList}
+          {...remainingProps}
+        />
+      );
+    }
+  };
+}
+
+export default function variantify(defaults = {}, variantNameComponents = {}) {
+  return compose(
+    withVariedInnerComponents(variantNameComponents, defaults.defaultVariant),
+    withVariantClassNameList(defaults)
+  );
+}

--- a/index.es6
+++ b/index.es6
@@ -24,12 +24,12 @@ export function withVariedInnerComponents({ variants = {}, defaultVariant }) {
   };
 }
 
-export function withVariantClassNameList({ variants = {}, defaultVariant }) {
+export function withVariantClassNameList({ variantsAvailable = [], defaultVariant }) {
   return (ComposedComponent) => class WithVariantClassNameListComponent extends Component {
 
     static get propTypes() {
       return {
-        variantName: PropTypes.oneOf(Object.keys(variants)),
+        variantName: PropTypes.oneOf(variantsAvailable),
       };
     }
 
@@ -63,9 +63,12 @@ export function withVariantClassNameList({ variants = {}, defaultVariant }) {
   };
 }
 
-export default function variantify(defaults = {}) {
+export default function variantify(config = {}) {
   return compose(
-    withVariedInnerComponents(defaults),
-    withVariantClassNameList(defaults)
+    withVariedInnerComponents(config),
+    withVariantClassNameList({
+      defaultVariant: config.defaultVariant,
+      variantsAvailable: Object.keys(config.variants),
+    })
   );
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,65 @@
+module.exports = function(config) {
+  const browsers = {
+    SauceChromeLatest: {
+      base: 'SauceLabs',
+      browserName: 'Chrome',
+    },
+    SauceFirefoxLatest: {
+      base: 'SauceLabs',
+      browserName: 'Firefox',
+    },
+    SauceSafariLatest: {
+      base: 'SauceLabs',
+      browserName: 'Safari',
+    },
+    SauceInternetExplorerLatest: {
+      base: 'SauceLabs',
+      browserName: 'Internet Explorer',
+    },
+    SauceEdgeLatest: {
+      base: 'SauceLabs',
+      browserName: 'MicrosoftEdge',
+    },
+    SauceIphoneLatest: {
+      base: 'SauceLabs',
+      browserName: 'iPad',
+    },
+    SauceAndroidLatest: {
+      base: 'SauceLabs',
+      browserName: 'Android',
+    },
+  };
+  config.set({
+    basePath: '',
+    frameworks: ['mocha', 'chai'],
+    files: [
+      require.resolve('chai-spies/chai-spies'),
+      require.resolve('chai-things/lib/chai-things'),
+      'testbundle.js'
+    ],
+    exclude: [
+    ],
+    preprocessors: {
+    },
+    reporters: ['progress', 'saucelabs'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    customLaunchers: browsers,
+    browserDisconnectTimeout: 1000 * 60 * 2,
+    browserNoActivityTimeout: 1000 * 60 * 2,
+    sauceLabs: {
+      testName: require('./package').name,
+      startConnect: true,
+      build: (function () {
+        if (process.env.GO_PIPELINE_NAME && process.env.GO_PIPELINE_LABEL) {
+          return process.env.GO_PIPELINE_NAME + '-' + process.env.GO_PIPELINE_LABEL;
+        }
+        return 'localbuild-' + new Date().toJSON();
+      })(),
+    },
+    browsers: Object.keys(browsers),
+    singleRun: true
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,181 @@
+{
+  "name": "component-variantify",
+  "version": "1.0.0",
+  "description": "HOCs to help create variants of components",
+  "author": "The Economist (http://economist.com)",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/economist-components/component-variantify.git"
+  },
+  "homepage": "https://github.com/economist-components/component-variantify#readme",
+  "bugs": {
+    "url": "https://github.com/economist-components/component-variantify/issues"
+  },
+  "main": "index.js",
+  "files": [
+    "*.js",
+    "*.es6",
+    "*.css",
+    "assets/*",
+    "!karma.conf.js",
+    "!testbundle.js"
+  ],
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
+  "babel": {
+    "stage": 0,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "rules": {
+      "func-style": 0
+    },
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "devpack-doc": {
+    "demohtml": {
+      "cmd": "babel-node -p \"require('react-dom/server').renderToString(require('./example'))\""
+    },
+    "css": [
+      {
+        "src": "./node_modules/mocha/mocha.css"
+      },
+      "./bundle.css"
+    ],
+    "js": [
+      {
+        "src": "./node_modules/mocha/mocha.js"
+      },
+      {
+        "src": "./node_modules/chai/chai.js"
+      },
+      {
+        "src": "./node_modules/chai-things/lib/chai-things.js"
+      },
+      {
+        "src": "./node_modules/chai-spies/chai-spies.js"
+      },
+      {
+        "contents": "chai.should();mocha.setup('bdd');"
+      },
+      "./testbundle.js",
+      {
+        "contents": "window.React = require('react');"
+      },
+      {
+        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
+      },
+      {
+        "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
+      }
+    ],
+    "sections": [
+      {
+        "title": "Readme",
+        "type": "markdown",
+        "src": "./README.md"
+      },
+      {
+        "title": "Example Code",
+        "type": "code",
+        "src": "./example.es6"
+      },
+      {
+        "title": "Tests",
+        "type": "html",
+        "contents": "<div id='mocha' class='test-output'></div>"
+      }
+    ]
+  },
+  "watch": {
+    "doc:html": [
+      "README.md",
+      "./*.js",
+      "package.json"
+    ]
+  },
+  "config": {
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js assets/"
+  },
+  "scripts": {
+    "ci": "./build.sh",
+    "doc": "parallelshell 'npm run doc:html' 'npm run doc:js' 'npm run doc:css'",
+    "doc:css": "cssnext --sourcemap example.css bundle.css",
+    "doc:css:watch": "npm run doc:css -- --watch",
+    "doc:html": "npm-assets . && devpack-doc index standalone",
+    "doc:html:watch": "npm-watch",
+    "doc:js": "npm run prepublish && browserify -d $npm_package_config_testbundle_opts",
+    "doc:js:watch": "watchify $npm_package_config_testbundle_opts",
+    "doc:watch": "parallelshell 'npm run doc:html:watch' 'npm run doc:js:watch' 'npm run doc:css:watch'",
+    "lint": "eslint $npm_package_config_lint_opts .",
+    "pages": "git stash save -u pages-stash && git branch -D gh-pages; git checkout --orphan gh-pages && git add -f $npm_package_config_ghpages_files && git commit -anm'ghpages' && git push origin HEAD:gh-pages -f",
+    "prepages": "npm run doc",
+    "prepublish": "babel . -d . -x .es6 --ignore node_modules",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
+    "provision": "devpack-configure ./package.json",
+    "serve": "browser-sync start --server --files '*.{html,js}'",
+    "test": "karma start",
+    "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
+  },
+  "dependencies": {
+    "lodash.compose": "^2.4.1",
+    "react": "^0.14.2"
+  },
+  "devDependencies": {
+    "@economist/component-devpack": "^3.5.0",
+    "babel": "^5.8.23",
+    "babel-eslint": "^4.1.3",
+    "babelify": "^6.3.0",
+    "browser-sync": "^2.8.2",
+    "browserify": "^11.0.1",
+    "chai": "^3.2.0",
+    "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
+    "cssnext": "^1.8.4",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^5.0.0",
+    "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
+    "eslint-plugin-react": "^3.3.1",
+    "karma": "^0.13.10",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.0",
+    "karma-sauce-launcher": "^0.2.14",
+    "mocha": "^2.2.5",
+    "npm-assets": "^0.1.0",
+    "npm-watch": "0.0.1",
+    "parallelshell": "^2.0.0",
+    "pre-commit": "^1.0.10",
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.2",
+    "react-dom": "^0.14.2",
+    "watchify": "^3.4.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0"
+  },
+  "keywords": [
+    "bem",
+    "classes",
+    "component",
+    "hoc",
+    "injection",
+    "props",
+    "variants"
+  ],
+  "pre-commit": [
+    "lint"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "lodash.compose": "^2.4.1",
     "react": "^0.14.2"
   },
   "devDependencies": {
@@ -158,13 +157,13 @@
     "npm-watch": "0.0.1",
     "parallelshell": "^2.0.0",
     "pre-commit": "^1.0.10",
-    "react": "^0.14.0",
+    "react": "^0.14.2",
     "react-addons-test-utils": "^0.14.2",
     "react-dom": "^0.14.2",
     "watchify": "^3.4.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.2"
   },
   "keywords": [
     "bem",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,1 @@
+{"extends":["strict","strict-react","strict/mocha"]}

--- a/test/index.es6
+++ b/test/index.es6
@@ -56,16 +56,15 @@ describe('variantify', () => {
             }
           }
 
-          const variantNameComponents = {
-            'variant-not-matched': {
-              'ArticleHeader': 'component-goes-here',
+          const config = {
+            defaultVariant: 'default-variant',
+            variants: {
+              'variant-not-matched': {
+                'ArticleHeader': 'component-goes-here',
+              },
             },
           };
-          const defaultVariant = 'default-variant';
-          const VariantComponent = withVariedInnerComponents(
-            variantNameComponents,
-            defaultVariant
-          )(ComposedComponent);
+          const VariantComponent = withVariedInnerComponents(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName="default-variant" />);
           const renderOutput = renderer.getRenderOutput();
           renderOutput.type.should.equal(ComposedComponent);
@@ -93,16 +92,15 @@ describe('variantify', () => {
             }
           }
 
-          const variantNameComponents = {
-            'variant-not-matched': {
-              'ArticleHeader': 'component-goes-here',
+          const config = {
+            defaultVariant: 'default-variant',
+            variants: {
+              'variant-not-matched': {
+                'ArticleHeader': 'component-goes-here',
+              },
             },
           };
-          const defaultVariant = 'default-variant';
-          const VariantComponent = withVariedInnerComponents(
-            variantNameComponents,
-            defaultVariant
-          )(ComposedComponent);
+          const VariantComponent = withVariedInnerComponents(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName="default-variant" />);
           const renderOutput = renderer.getRenderOutput();
           renderOutput.type.should.equal(ComposedComponent);
@@ -120,24 +118,23 @@ describe('variantify', () => {
             }
           }
 
-          const variantNameComponents = {
-            'default-variant': {
-              'ArticleHeader': 'component-goes-here',
-            },
-            'picked-variant': {
-              'ArticleHeader': 'picked-component',
+          const config = {
+            defaultVariant: 'default-variant',
+            variants: {
+              'default-variant': {
+                'ArticleHeader': 'component-goes-here',
+              },
+              'picked-variant': {
+                'ArticleHeader': 'picked-component',
+              },
             },
           };
-          const defaultVariant = 'default-variant';
           const variantName = 'picked-variant';
-          const VariantComponent = withVariedInnerComponents(
-            variantNameComponents,
-            defaultVariant
-          )(ComposedComponent);
+          const VariantComponent = withVariedInnerComponents(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName={variantName} />);
           const renderOutput = renderer.getRenderOutput();
           renderOutput.type.should.equal(ComposedComponent);
-          renderOutput.props.components.should.deep.equal(variantNameComponents[variantName]);
+          renderOutput.props.components.should.deep.equal(config.variants[variantName]);
         });
 
       });
@@ -151,20 +148,19 @@ describe('variantify', () => {
             }
           }
 
-          const variantNameComponents = {
-            'default-variant': {
-              'ArticleHeader': 'component-goes-here',
+          const config = {
+            defaultVariant: 'default-variant',
+            variants: {
+              'default-variant': {
+                'ArticleHeader': 'component-goes-here',
+              },
             },
           };
-          const defaultVariant = 'default-variant';
-          const VariantComponent = withVariedInnerComponents(
-            variantNameComponents,
-            defaultVariant
-          )(ComposedComponent);
+          const VariantComponent = withVariedInnerComponents(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName="does-not-match" />);
           const renderOutput = renderer.getRenderOutput();
           renderOutput.type.should.equal(ComposedComponent);
-          renderOutput.props.components.should.deep.equal(variantNameComponents[defaultVariant]);
+          renderOutput.props.components.should.deep.equal(config.variants[config.defaultVariant]);
         });
 
       });
@@ -188,11 +184,12 @@ describe('variantify', () => {
             return <div>Hello there <span>fellow developer</span>.</div>;
           }
         }
-
-        const VariantComponent = withVariantClassNameList({
-          variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+        const config = {
           defaultVariant: 'variant-a',
-        })(ComposedComponent);
+          availableVariants: [ 'variant-a', 'variant-b', 'variant-c' ],
+        };
+
+        const VariantComponent = withVariantClassNameList(config)(ComposedComponent);
         renderer.render(<VariantComponent variantName="variant-a" />);
         const renderOutput = renderer.getRenderOutput();
         renderOutput.type.should.equal(ComposedComponent);
@@ -207,11 +204,12 @@ describe('variantify', () => {
               return <div>Hello there <span>fellow developer</span>.</div>;
             }
           }
-
-          const VariantComponent = withVariantClassNameList({
-            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          const config = {
             defaultVariant: 'variant-a',
-          })(ComposedComponent);
+            availableVariants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          };
+
+          const VariantComponent = withVariantClassNameList(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName="variant-a" />);
           const renderOutput = renderer.getRenderOutput();
           const generateClassNameList = renderOutput.props.generateClassNameList;
@@ -224,11 +222,12 @@ describe('variantify', () => {
               return <div>Hello there <span>fellow developer</span>.</div>;
             }
           }
-
-          const VariantComponent = withVariantClassNameList({
-            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          const config = {
             defaultVariant: 'variant-a',
-          })(ComposedComponent);
+            availableVariants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          };
+
+          const VariantComponent = withVariantClassNameList(config)(ComposedComponent);
           renderer.render(<VariantComponent variantName="variant-a" />);
           const renderOutput = renderer.getRenderOutput();
           const generateClassNameList = renderOutput.props.generateClassNameList;
@@ -241,11 +240,12 @@ describe('variantify', () => {
               return <div>Hello there <span>fellow developer</span>.</div>;
             }
           }
-
-          const VariantComponent = withVariantClassNameList({
-            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          const config = {
             defaultVariant: null,
-          })(ComposedComponent);
+            availableVariants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          };
+
+          const VariantComponent = withVariantClassNameList(config)(ComposedComponent);
           renderer.render(<VariantComponent />);
           const renderOutput = renderer.getRenderOutput();
           const generateClassNameList = renderOutput.props.generateClassNameList;

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,0 +1,261 @@
+/* eslint react/no-multi-comp: 0, init-declarations: 0, id-length: 0, id-match: 0 */
+import React from 'react';
+import { createRenderer } from 'react-addons-test-utils';
+
+import variantify from '..';
+import {
+  defaultGenerateClassNameList,
+  withVariedInnerComponents,
+  withVariantClassNameList,
+} from '..';
+
+import chai from 'chai';
+const should = chai.should();
+describe('variantify', () => {
+
+  it('the composition of the HOCs should be exposed as default', () => {
+    should.exist(variantify);
+  });
+
+  it('has defaultGenerateClassNameList exposed', () => {
+    should.exist(defaultGenerateClassNameList);
+  });
+
+  it('has withVariedInnerComponents exposed', () => {
+    should.exist(withVariedInnerComponents);
+  });
+
+  it('has withVariantClassNameList exposed', () => {
+    should.exist(withVariantClassNameList);
+  });
+
+  describe('defaultGenerateClassNameList', () => {
+
+    it('should return an array containing the element passed in', () => {
+      const element = 'ClassName';
+      defaultGenerateClassNameList(element).should.deep.equal([ element ]);
+    });
+
+  });
+
+  describe('withVariedInnerComponents', () => {
+
+    describe('props.components', () => {
+
+      let renderer;
+      beforeEach(() => {
+        renderer = createRenderer();
+      });
+
+      describe('with no components in composed component\'s defaultProps and no matching variantNameComponents', () => {
+
+        it('should pass in an empty object', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const variantNameComponents = {
+            'variant-not-matched': {
+              'ArticleHeader': 'component-goes-here',
+            },
+          };
+          const defaultVariant = 'default-variant';
+          const VariantComponent = withVariedInnerComponents(
+            variantNameComponents,
+            defaultVariant
+          )(ComposedComponent);
+          renderer.render(<VariantComponent variantName="default-variant" />);
+          const renderOutput = renderer.getRenderOutput();
+          renderOutput.type.should.equal(ComposedComponent);
+          renderOutput.props.components.should.deep.equal({});
+        });
+
+      });
+
+      describe('with components in composed component\'s defaultProps and no matching variantName or default', () => {
+
+        it('should pass in the defaultProps components', () => {
+          class ComposedComponent extends React.Component {
+            static get defaultProps() {
+              return {
+                'components': {
+                  'default-variant': {
+                    'ArticleHeader': 'component-found-here',
+                  },
+                },
+              };
+            }
+
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const variantNameComponents = {
+            'variant-not-matched': {
+              'ArticleHeader': 'component-goes-here',
+            },
+          };
+          const defaultVariant = 'default-variant';
+          const VariantComponent = withVariedInnerComponents(
+            variantNameComponents,
+            defaultVariant
+          )(ComposedComponent);
+          renderer.render(<VariantComponent variantName="default-variant" />);
+          const renderOutput = renderer.getRenderOutput();
+          renderOutput.type.should.equal(ComposedComponent);
+          renderOutput.props.components.should.deep.equal(ComposedComponent.defaultProps.components);
+        });
+
+      });
+
+      describe('with no components in composed component\'s defaultProps and matching variantName', () => {
+
+        it('should pass in the matching variantNameComponents object', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const variantNameComponents = {
+            'default-variant': {
+              'ArticleHeader': 'component-goes-here',
+            },
+            'picked-variant': {
+              'ArticleHeader': 'picked-component',
+            },
+          };
+          const defaultVariant = 'default-variant';
+          const variantName = 'picked-variant';
+          const VariantComponent = withVariedInnerComponents(
+            variantNameComponents,
+            defaultVariant
+          )(ComposedComponent);
+          renderer.render(<VariantComponent variantName={variantName} />);
+          const renderOutput = renderer.getRenderOutput();
+          renderOutput.type.should.equal(ComposedComponent);
+          renderOutput.props.components.should.deep.equal(variantNameComponents[variantName]);
+        });
+
+      });
+
+      describe('with no components in composed component\'s defaultProps and matching default', () => {
+
+        it('should pass in the default variantNameComponents object', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const variantNameComponents = {
+            'default-variant': {
+              'ArticleHeader': 'component-goes-here',
+            },
+          };
+          const defaultVariant = 'default-variant';
+          const VariantComponent = withVariedInnerComponents(
+            variantNameComponents,
+            defaultVariant
+          )(ComposedComponent);
+          renderer.render(<VariantComponent variantName="does-not-match" />);
+          const renderOutput = renderer.getRenderOutput();
+          renderOutput.type.should.equal(ComposedComponent);
+          renderOutput.props.components.should.deep.equal(variantNameComponents[defaultVariant]);
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('withVariantClassNameList', () => {
+
+    describe('props.generateClassNameList', () => {
+
+      let renderer;
+      beforeEach(() => {
+        renderer = createRenderer();
+      });
+
+      it('should be passed into the composed component', () => {
+        class ComposedComponent extends React.Component {
+          render() {
+            return <div>Hello there <span>fellow developer</span>.</div>;
+          }
+        }
+
+        const VariantComponent = withVariantClassNameList({
+          variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+          defaultVariant: 'variant-a',
+        })(ComposedComponent);
+        renderer.render(<VariantComponent variantName="variant-a" />);
+        const renderOutput = renderer.getRenderOutput();
+        renderOutput.type.should.equal(ComposedComponent);
+        renderOutput.props.generateClassNameList.should.be.a('function');
+      });
+
+      describe('should generate a list containing', () => {
+
+        it('the class that is passed in', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const VariantComponent = withVariantClassNameList({
+            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+            defaultVariant: 'variant-a',
+          })(ComposedComponent);
+          renderer.render(<VariantComponent variantName="variant-a" />);
+          const renderOutput = renderer.getRenderOutput();
+          const generateClassNameList = renderOutput.props.generateClassNameList;
+          generateClassNameList('ClassName').should.include('ClassName');
+        });
+
+        it('a variant-specific class from the class that is passed in; iff variantName', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const VariantComponent = withVariantClassNameList({
+            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+            defaultVariant: 'variant-a',
+          })(ComposedComponent);
+          renderer.render(<VariantComponent variantName="variant-a" />);
+          const renderOutput = renderer.getRenderOutput();
+          const generateClassNameList = renderOutput.props.generateClassNameList;
+          generateClassNameList('ClassName').should.include('variant-a-ClassName');
+        });
+
+        it('no variant-specific class from the class that is passed in; iff no variantName', () => {
+          class ComposedComponent extends React.Component {
+            render() {
+              return <div>Hello there <span>fellow developer</span>.</div>;
+            }
+          }
+
+          const VariantComponent = withVariantClassNameList({
+            variants: [ 'variant-a', 'variant-b', 'variant-c' ],
+            defaultVariant: null,
+          })(ComposedComponent);
+          renderer.render(<VariantComponent />);
+          const renderOutput = renderer.getRenderOutput();
+          const generateClassNameList = renderOutput.props.generateClassNameList;
+          generateClassNameList('ClassName').should.not.include('variant-a-ClassName');
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is an initial version of `component-variantify` and an attempt to share logic that I created to solve [problems surfaced by trying to share the `component-articletemplate` code amongst different world-if & world-in variants](https://github.com/economist-components/component-articletemplate/pull/11) (both changes to styling and the HTML structure.)

See: https://github.com/economist-components/component-articletemplate/issues/22

___________________________

# [Read the `README.md` here](https://github.com/sebinsua/component-variantify/blob/master/README.md)